### PR TITLE
Use IOwinRequest.IsSecure to determine whether a connection uses TLS.

### DIFF
--- a/Owin.Hsts.Tests/HstsMiddlewareTests.cs
+++ b/Owin.Hsts.Tests/HstsMiddlewareTests.cs
@@ -25,7 +25,7 @@ namespace Owin.Hsts.Tests
             _mockContext.Setup(c => c.Request).Returns(_mockRequest.Object);
             _stubResponse = new StubResponse(_mockContext.Object);
             _mockContext.Setup(c => c.Response).Returns(_stubResponse);
-            _mockRequest.Setup(r => r.Scheme).Returns("https");  //Default the request to https
+            _mockRequest.Setup(r => r.IsSecure).Returns(true);  //Default the request to https
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace Owin.Hsts.Tests
         {
             // Arrange
             var middleware = new HstsMiddleware(null);
-            _mockRequest.Setup(r => r.Scheme).Returns("http");
+            _mockRequest.Setup(r => r.IsSecure).Returns(false);
 
             // Act
             await middleware.Invoke(_mockContext.Object);

--- a/Owin.Hsts.Tests/Owin.Hsts.Tests.csproj
+++ b/Owin.Hsts.Tests/Owin.Hsts.Tests.csproj
@@ -64,6 +64,9 @@
       <Name>Owin.Hsts</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Owin.Hsts.Tests/Owin.Hsts.Tests.csproj
+++ b/Owin.Hsts.Tests/Owin.Hsts.Tests.csproj
@@ -64,9 +64,6 @@
       <Name>Owin.Hsts</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Owin.Hsts/HstsMiddleware.cs
+++ b/Owin.Hsts/HstsMiddleware.cs
@@ -30,7 +30,7 @@ namespace Owin.Hsts
         {
             // Header must not be set on non https calls
             // ref: http://tools.ietf.org/html/rfc6797#section-7.2
-            if (SchemeIsNotHttps(context))
+            if (!context.Request.IsSecure)
             {
                 await InvokeNext(context);
                 return;
@@ -70,11 +70,6 @@ namespace Owin.Hsts
             {
                 await Next.Invoke(context);
             }
-        }
-
-        private static bool SchemeIsNotHttps(IOwinContext context)
-        {
-            return !context.Request.Scheme.Equals("https", StringComparison.Ordinal);
         }
     }
 


### PR DESCRIPTION
Instead of checking the request URL scheme manually, simply use the IOwinRequest.IsSecure property. The documentation for this property states that this is its purpose so the scheme check is just unnecessary code.

See issue #3.